### PR TITLE
generate: fix duplicated .name

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -61,6 +61,7 @@ for CONFIG in *.sh; do
 		echo "obj-\$($kconfig) += $driver.o" >> "$OUT_DIR/Makefile"
 		cp "$panel"/panel-!(simple-*).c "$OUT_DIR/$driver.c"
 		sed -Ei "s/\.compatible = \".+\"/.compatible = \"$compatible\"/g" "$OUT_DIR/$driver.c"
+		sed -Ei "s/\.name = \".+\"/.name = \"$driver\"/g" "$OUT_DIR/$driver.c"
 	done
 done
 new_panel_drivers=("$OUT_DIR"/panel-*.c)


### PR DESCRIPTION
```
[    1.727530] Error: Driver 'panel-hx8394d' is already registered, aborting...
```