### PR TITLE
config/dtb: samsung-heatqlte: Enable backlight

### DIFF
--- a/config/samsung-heatqlte.sh
+++ b/config/samsung-heatqlte.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # DTB: From AP_G357FZXXS1AQA2_CL572060_QB12156321_REV00_user_low_ship_MULTI_CERT.tar
 
-OPTIONS=(-r vddio -r vdd --no-backlight)
+OPTIONS=(-r vddio -r vdd)
 PANELS=(
 	[samsung_wvga_video]="samsung,s6288a0"
 )


### PR DESCRIPTION
A new WIP patch in msm8916-mainline (https://github.com/msm8916-mainline/linux/pull/358) enables backlight control for this device's panel. Re-enable backlight code stub generation for it to base on top of
