### PR TITLE
config/huawei-kiwi: add huawei,kiwi-auo-otm1901a panel driver

### DIFF
--- a/config/huawei-kiwi.sh
+++ b/config/huawei-kiwi.sh
@@ -4,6 +4,7 @@
 
 OPTIONS=(-r vsp -r vsn --dumb-dcs)
 PANELS=(
+        [auo_otm1901a_5p5_1080pxa_video]="huawei,kiwi-auo-otm1901a"
 	[cmi_nt35532_5p5_1080pxa_video]="huawei,kiwi-cmi-nt35532"
 	[tianma_nt35596_5p5_1080pxa_video]="huawei,kiwi-tianma-nt35596"
 )


### PR DESCRIPTION
i've tested the panel and it works perfectly well besides one thing - changing the brightness seems to send invalid commands and the panel does weird things (and doesnt actually change the brightness)
i've tried using other combinations of the commands but any of them either causes the panel to not turn on at all or work but with the same issues